### PR TITLE
Update tutorial-load-dataset.asciidoc for the new mapping changes.

### DIFF
--- a/docs/getting-started/tutorial-load-dataset.asciidoc
+++ b/docs/getting-started/tutorial-load-dataset.asciidoc
@@ -164,11 +164,9 @@ GET /_cat/indices?v
 
 //CONSOLE
 
-
-
 You should see output similar to the following:
 
-[source,js]
+[source,shell]
 health status index               pri rep docs.count docs.deleted store.size pri.store.size
 yellow open   bank                  5   1       1000            0    418.2kb        418.2kb
 yellow open   shakespeare           5   1     111396            0     17.6mb         17.6mb

--- a/docs/getting-started/tutorial-load-dataset.asciidoc
+++ b/docs/getting-started/tutorial-load-dataset.asciidoc
@@ -78,7 +78,7 @@ curl -H 'Content-Type: application/json' -XPUT http://localhost:9200/shakespeare
 
 This mapping specifies the following qualities for the data set:
 
-* The _speaker_ field is a keyword that isn't analyzed. The text in this field is treated as a single unit, even if
+* The _speaker_ field is a field that isn't analyzed. The text in this field is treated as a single unit, even if
 there are multiple words in the field.
 * The same applies to the _play_name_ field.
 * The _line_id_ and _speech_number_ fields are integers.

--- a/docs/getting-started/tutorial-load-dataset.asciidoc
+++ b/docs/getting-started/tutorial-load-dataset.asciidoc
@@ -79,7 +79,7 @@ PUT /shakespeare
 
 This mapping specifies the following qualities for the data set:
 
-* Because, the _speaker_ and _play_name_ fields are keyword fields, they are not analyzed. The strings are treated as a single unit even if they contain multiple words.
+* Because the _speaker_ and _play_name_ fields are keyword fields, they are not analyzed. The strings are treated as a single unit even if they contain multiple words.
 * The _line_id_ and _speech_number_ fields are integers.
 
 The logs data set requires a mapping to label the latitude/longitude pairs in the logs as geographic locations by
@@ -159,8 +159,10 @@ These commands may take some time to execute, depending on the computing resourc
 
 Verify successful loading with the following command:
 
-[source,shell]
-curl 'localhost:9200/_cat/indices?v'
+[source,js]
+GET /_cat/indices?v
+
+//CONSOLE
 
 
 

--- a/docs/getting-started/tutorial-load-dataset.asciidoc
+++ b/docs/getting-started/tutorial-load-dataset.asciidoc
@@ -60,8 +60,8 @@ field's searchability or whether or not it's _tokenized_, or broken up into sepa
 
 Use the following command in a terminal (eg `bash`) to set up a mapping for the Shakespeare data set:
 
-[source,shell]
-curl -H 'Content-Type: application/json' -XPUT http://localhost:9200/shakespeare -d '
+[source,js]
+PUT /shakespeare
 {
  "mappings" : {
   "_default_" : {
@@ -74,13 +74,12 @@ curl -H 'Content-Type: application/json' -XPUT http://localhost:9200/shakespeare
   }
  }
 }
-';
+
+//CONSOLE
 
 This mapping specifies the following qualities for the data set:
 
-* The _speaker_ field is a field that isn't analyzed. The text in this field is treated as a single unit, even if
-there are multiple words in the field.
-* The same applies to the _play_name_ field.
+* Because, the _speaker_ and _play_name_ fields are keyword fields, they are not analyzed. The strings are treated as a single unit even if they contain multiple words.
 * The _line_id_ and _speech_number_ fields are integers.
 
 The logs data set requires a mapping to label the latitude/longitude pairs in the logs as geographic locations by
@@ -88,8 +87,8 @@ applying the `geo_point` type to those fields.
 
 Use the following commands to establish `geo_point` mapping for the logs:
 
-[source,shell]
-curl -H 'Content-Type: application/json' -XPUT http://localhost:9200/logstash-2015.05.18 -d '
+[source,js]
+PUT /logstash-2015.05.18
 {
   "mappings": {
     "log": {
@@ -105,29 +104,11 @@ curl -H 'Content-Type: application/json' -XPUT http://localhost:9200/logstash-20
     }
   }
 }
-';
 
-[source,shell]
-curl -H 'Content-Type: application/json' -XPUT http://localhost:9200/logstash-2015.05.19 -d '
-{
-  "mappings": {
-    "log": {
-      "properties": {
-        "geo": {
-          "properties": {
-            "coordinates": {
-              "type": "geo_point"
-            }
-          }
-        }
-      }
-    }
-  }
-}
-';
+//CONSOLE
 
-[source,shell]
-curl -H 'Content-Type: application/json' -XPUT http://localhost:9200/logstash-2015.05.20 -d '
+[source,js]
+PUT /logstash-2015.05.19
 {
   "mappings": {
     "log": {
@@ -143,7 +124,28 @@ curl -H 'Content-Type: application/json' -XPUT http://localhost:9200/logstash-20
     }
   }
 }
-';
+
+//CONSOLE
+
+[source,js]
+PUT /logstash-2015.05.20
+{
+  "mappings": {
+    "log": {
+      "properties": {
+        "geo": {
+          "properties": {
+            "coordinates": {
+              "type": "geo_point"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//CONSOLE
 
 The accounts data set doesn't require any mappings, so at this point we're ready to use the Elasticsearch
 {es-ref}docs-bulk.html[`bulk`] API to load the data sets with the following commands:
@@ -157,12 +159,14 @@ These commands may take some time to execute, depending on the computing resourc
 
 Verify successful loading with the following command:
 
-[source,shell]
-curl 'localhost:9200/_cat/indices?v'
+[source,js]
+GET /_cat/indices?v
+
+//CONSOLE
 
 You should see output similar to the following:
 
-[source,shell]
+[source,js]
 health status index               pri rep docs.count docs.deleted store.size pri.store.size
 yellow open   bank                  5   1       1000            0    418.2kb        418.2kb
 yellow open   shakespeare           5   1     111396            0     17.6mb         17.6mb

--- a/docs/getting-started/tutorial-load-dataset.asciidoc
+++ b/docs/getting-started/tutorial-load-dataset.asciidoc
@@ -159,10 +159,10 @@ These commands may take some time to execute, depending on the computing resourc
 
 Verify successful loading with the following command:
 
-[source,js]
-GET /_cat/indices?v
+[source,shell]
+curl 'localhost:9200/_cat/indices?v'
 
-//CONSOLE
+
 
 You should see output similar to the following:
 

--- a/docs/getting-started/tutorial-load-dataset.asciidoc
+++ b/docs/getting-started/tutorial-load-dataset.asciidoc
@@ -66,8 +66,8 @@ curl -H 'Content-Type: application/json' -XPUT http://localhost:9200/shakespeare
  "mappings" : {
   "_default_" : {
    "properties" : {
-    "speaker" : {"type": "string", "index" : "not_analyzed" },
-    "play_name" : {"type": "string", "index" : "not_analyzed" },
+    "speaker" : {"type": "keyword" },
+    "play_name" : {"type": "keyword" },
     "line_id" : { "type" : "integer" },
     "speech_number" : { "type" : "integer" }
    }
@@ -78,7 +78,7 @@ curl -H 'Content-Type: application/json' -XPUT http://localhost:9200/shakespeare
 
 This mapping specifies the following qualities for the data set:
 
-* The _speaker_ field is a string that isn't analyzed. The string in this field is treated as a single unit, even if
+* The _speaker_ field is a keyword that isn't analyzed. The text in this field is treated as a single unit, even if
 there are multiple words in the field.
 * The same applies to the _play_name_ field.
 * The _line_id_ and _speech_number_ fields are integers.


### PR DESCRIPTION
This PR is for fixing load sample data into kibana website for 6.0.0_alpha1 https://www.elastic.co/guide/en/kibana/master/tutorial-load-dataset.html

I have updated the mapping for string -> keyword. 

1. Do we change the schema on the page to reflect ES mappings? Specifically do I change INT to long? and all the strings into text fields? According to this? 
https://www.elastic.co/guide/en/elasticsearch/reference/master/mapping.html#mapping

2. Do I remove the "_default_" :  from the curl command to create mapping?

The data files for logs and accounts.zip are fine. I do need to change the shakespeare.json and pass it to Deb to upload it.

