### PR TITLE
Changing shakespeare bulk upload command for 6.0

### DIFF
--- a/docs/getting-started/tutorial-load-dataset.asciidoc
+++ b/docs/getting-started/tutorial-load-dataset.asciidoc
@@ -150,7 +150,7 @@ The accounts data set doesn't require any mappings, so at this point we're ready
 
 [source,shell]
 curl -H 'Content-Type: application/x-ndjson' -XPOST 'localhost:9200/bank/account/_bulk?pretty' --data-binary @accounts.json
-curl -H 'Content-Type: application/x-ndjson' -XPOST 'localhost:9200/shakespeare/_bulk?pretty' --data-binary @shakespeare.json
+curl -H 'Content-Type: application/x-ndjson' -XPOST 'localhost:9200/shakespeare/doc/_bulk?pretty' --data-binary @shakespeare.json
 curl -H 'Content-Type: application/x-ndjson' -XPOST 'localhost:9200/_bulk?pretty' --data-binary @logs.jsonl
 
 These commands may take some time to execute, depending on the computing resources available.


### PR DESCRIPTION
Changing the bulk upload command for shakespeare.json to work with the new data file for 6.0.0 release.

We need to use a different path for 6.x(master) and 5.x for shakespeare.json now. 
Sending the shakespeare.json to Court to get the new path. 