### PR TITLE
[Lens] kbnArchiver remove loading inside scenarios

### DIFF
--- a/x-pack/test/functional/apps/lens/index.ts
+++ b/x-pack/test/functional/apps/lens/index.ts
@@ -18,26 +18,27 @@ export default function ({ getService, loadTestFile, getPageObjects }: FtrProvid
     before(async () => {
       log.debug('Starting lens before method');
       await browser.setWindowSize(1280, 800);
+      await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
       await kibanaServer.importExport.load(
         'x-pack/test/functional/fixtures/kbn_archiver/lens/lens_basic.json'
       );
-      await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
       // changing the timepicker default here saves us from having to set it in Discover (~8s)
       await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();
       await kibanaServer.uiSettings.update({ defaultIndex: 'logstash-*', 'dateFormat:tz': 'UTC' });
     });
 
     after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+      await PageObjects.timePicker.resetDefaultAbsoluteRangeViaUiSettings();
       await kibanaServer.importExport.unload(
         'x-pack/test/functional/fixtures/kbn_archiver/lens/lens_basic.json'
       );
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
-      await PageObjects.timePicker.resetDefaultAbsoluteRangeViaUiSettings();
     });
 
     describe('', function () {
       this.tags(['ciGroup3', 'skipFirefox']);
       loadTestFile(require.resolve('./smokescreen'));
+      loadTestFile(require.resolve('./persistent_context'));
     });
 
     describe('', function () {
@@ -47,7 +48,6 @@ export default function ({ getService, loadTestFile, getPageObjects }: FtrProvid
       loadTestFile(require.resolve('./table'));
       loadTestFile(require.resolve('./runtime_fields'));
       loadTestFile(require.resolve('./dashboard'));
-      loadTestFile(require.resolve('./persistent_context'));
       loadTestFile(require.resolve('./colors'));
       loadTestFile(require.resolve('./chart_data'));
       loadTestFile(require.resolve('./time_shift'));

--- a/x-pack/test/functional/apps/lens/index.ts
+++ b/x-pack/test/functional/apps/lens/index.ts
@@ -45,23 +45,22 @@ export default function ({ getService, loadTestFile, getPageObjects }: FtrProvid
 
       loadTestFile(require.resolve('./add_to_dashboard'));
       loadTestFile(require.resolve('./table'));
-      //       loadTestFile(require.resolve('./runtime_fields'));
-      //       loadTestFile(require.resolve('./dashboard'));
-      //       loadTestFile(require.resolve('./persistent_context'));
-      //       loadTestFile(require.resolve('./colors'));
-      //       loadTestFile(require.resolve('./chart_data'));
-      //       loadTestFile(require.resolve('./time_shift'));
-      //       loadTestFile(require.resolve('./drag_and_drop'));
-      //       loadTestFile(require.resolve('./geo_field'));
-      //       loadTestFile(require.resolve('./lens_reporting'));
-      //       loadTestFile(require.resolve('./lens_tagging'));
-      //       loadTestFile(require.resolve('./formula'));
-      //       loadTestFile(require.resolve('./heatmap'));
-      //       loadTestFile(require.resolve('./reference_lines'));
-      //       loadTestFile(require.resolve('./inspector'));
-
-      //       // has to be last one in the suite because it overrides saved objects
-      //       loadTestFile(require.resolve('./rollup'));
+      loadTestFile(require.resolve('./runtime_fields'));
+      loadTestFile(require.resolve('./dashboard'));
+      loadTestFile(require.resolve('./persistent_context'));
+      loadTestFile(require.resolve('./colors'));
+      loadTestFile(require.resolve('./chart_data'));
+      loadTestFile(require.resolve('./time_shift'));
+      loadTestFile(require.resolve('./drag_and_drop'));
+      loadTestFile(require.resolve('./geo_field'));
+      loadTestFile(require.resolve('./formula'));
+      loadTestFile(require.resolve('./heatmap'));
+      loadTestFile(require.resolve('./reference_lines'));
+      loadTestFile(require.resolve('./inspector'));
+      loadTestFile(require.resolve('./lens_tagging'));
+      loadTestFile(require.resolve('./lens_reporting'));
+      // has to be last one in the suite because it overrides saved objects
+      loadTestFile(require.resolve('./rollup'));
     });
   });
 }

--- a/x-pack/test/functional/apps/lens/lens_tagging.ts
+++ b/x-pack/test/functional/apps/lens/lens_tagging.ts
@@ -11,11 +11,10 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const listingTable = getService('listingTable');
   const testSubjects = getService('testSubjects');
-  const esArchiver = getService('esArchiver');
   const retry = getService('retry');
+  const esArchiver = getService('esArchiver');
   const find = getService('find');
   const dashboardAddPanel = getService('dashboardAddPanel');
-  const kibanaServer = getService('kibanaServer');
   const dashboardPanelActions = getService('dashboardPanelActions');
   const PageObjects = getPageObjects([
     'common',
@@ -34,20 +33,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
       await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.load(
-        'x-pack/test/functional/fixtures/kbn_archiver/lens/lens_basic.json'
-      );
       await PageObjects.common.navigateToApp('dashboard');
       await PageObjects.dashboard.preserveCrossAppState();
       await PageObjects.dashboard.clickNewDashboard();
     });
 
     after(async () => {
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
       await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(
-        'x-pack/test/functional/fixtures/kbn_archiver/lens/lens_basic.json'
-      );
     });
 
     it('adds a new tag to a Lens visualization', async () => {

--- a/x-pack/test/functional/apps/lens/table.ts
+++ b/x-pack/test/functional/apps/lens/table.ts
@@ -14,6 +14,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const find = getService('find');
   const retry = getService('retry');
   const testSubjects = getService('testSubjects');
+  const screenshot = getService('screenshots');
 
   describe('lens datatable', () => {
     it('should able to sort a table by a column', async () => {
@@ -56,12 +57,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should allow to configure column visibility', async () => {
+      screenshot.take('toggleColumnVisibility0: before');
       expect(await PageObjects.lens.getDatatableHeaderText(0)).to.equal('Top values of ip');
       expect(await PageObjects.lens.getDatatableHeaderText(1)).to.equal('@timestamp per 3 hours');
       expect(await PageObjects.lens.getDatatableHeaderText(2)).to.equal('Average of bytes');
 
       await PageObjects.lens.toggleColumnVisibility('lnsDatatable_rows > lns-dimensionTrigger');
 
+      screenshot.take('toggleColumnVisibility9: after');
       expect(await PageObjects.lens.getDatatableHeaderText(0)).to.equal('@timestamp per 3 hours');
       expect(await PageObjects.lens.getDatatableHeaderText(1)).to.equal('Average of bytes');
 

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -19,6 +19,7 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
   const comboBox = getService('comboBox');
   const browser = getService('browser');
   const dashboardAddPanel = getService('dashboardAddPanel');
+  const screenshot = getService('screenshots');
 
   const PageObjects = getPageObjects([
     'common',
@@ -875,12 +876,17 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     },
 
     async toggleColumnVisibility(dimension: string) {
+      screenshot.take('toggleColumnVisibility1:before');
       await this.openDimensionEditor(dimension);
+      screenshot.take('toggleColumnVisibility2:opensDimensionEditor');
       const id = 'lns-table-column-hidden';
       const isChecked = await testSubjects.isEuiSwitchChecked(id);
       await testSubjects.setEuiSwitch(id, isChecked ? 'uncheck' : 'check');
+      screenshot.take('toggleColumnVisibility3:Changedswitch');
       await this.closeDimensionEditor();
+      screenshot.take('toggleColumnVisibility4:closeDimensionEditor');
       await PageObjects.header.waitUntilLoadingHasFinished();
+      screenshot.take('toggleColumnVisibility5:loadingfinished');
     },
 
     async clickTableCellAction(rowIndex = 0, colIndex = 0, actionTestSub: string) {


### PR DESCRIPTION
## Summary

Tested this locally and works locally, now checking in the test runner and [here](https://github.com/elastic/kibana/pull/115154) 
The problem might lay in the fact that:
- we load the 'x-pack/test/functional/fixtures/kbn_archiver/lens/lens_basic.json' file in the lens/index file `before` all the tests, 
- and then load it again in `lens_tagging` file `before` all the tests (that's harmless) 
- and unload it at the end of `lens_tagging` file `after` all the tests  (auch!!!!)
- the next file - `formula` file cannot execute properly. 